### PR TITLE
Update 06-auto-router.md

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/06-auto-router.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/06-auto-router.md
@@ -156,7 +156,7 @@ const WETH = new Token(
 );
 
 const USDC = new Token(
-  ChainId.MAINNET,
+  1,
   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   6,
   'USDC',


### PR DESCRIPTION
This fix a code bug, because `ChainId` were never called

Also the code just above 
```
const WETH = new Token(
  1,
  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
  18,
  'WETH',
  'Wrapped Ether'
);
```

Is also like this